### PR TITLE
Encoding error fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ PKGNAME = "whotracksme"
 
 
 LONG_DESCRIPTION = ""
-with pathlib.Path("README.md").open() as readme_file:
+with pathlib.Path("README.md").open(encoding='utf-8') as readme_file:
     LONG_DESCRIPTION = readme_file.read()
 
 


### PR DESCRIPTION
Hopefully this will fix the following installation error:

```
15:11:48 Collecting git+https://github.com/cliqz-oss/whotracks.me.git
15:11:48   Cloning https://github.com/cliqz-oss/whotracks.me.git to /tmp/pip-idy4mcwx-build
15:12:33     Complete output from command python setup.py egg_info:
15:12:33     Traceback (most recent call last):
15:12:33       File "<string>", line 1, in <module>
15:12:33       File "/tmp/pip-idy4mcwx-build/setup.py", line 16, in <module>
15:12:33         LONG_DESCRIPTION = readme_file.read()
15:12:33       File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
15:12:33         return codecs.ascii_decode(input, self.errors)[0]
15:12:33     UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 290: ordinal not in range(128)
```