### PR TITLE
Data Jan 2021

### DIFF
--- a/whotracksme/data/assets/2021-01/de/companies.csv
+++ b/whotracksme/data/assets/2021-01/de/companies.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d569dfda0db5d5371b3f4874be0a966899650f50721f599f2100941654341627
+size 245225

--- a/whotracksme/data/assets/2021-01/de/domains.csv
+++ b/whotracksme/data/assets/2021-01/de/domains.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0042c500fd81fb7211ee04b03e6be45069016728aa2d1b64e105af028e9b247f
+size 869804

--- a/whotracksme/data/assets/2021-01/de/sites.csv
+++ b/whotracksme/data/assets/2021-01/de/sites.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1281e8f090fa5df6ea6ba452045078f4e708eddbbd93132c3f433a211ffbec7
+size 3115690

--- a/whotracksme/data/assets/2021-01/de/sites_trackers.csv
+++ b/whotracksme/data/assets/2021-01/de/sites_trackers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef5e07b07f1e83c41e599a9a834444a7d5e821a0c9c65f21e0d5206b10e31ec8
+size 40498895

--- a/whotracksme/data/assets/2021-01/de/trackers.csv
+++ b/whotracksme/data/assets/2021-01/de/trackers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4d3e9c2d28ff8b6a64c38826753ef3a249e550058cace5e0fe59ec2c10b1b43
+size 378340

--- a/whotracksme/data/assets/2021-01/eu/companies.csv
+++ b/whotracksme/data/assets/2021-01/eu/companies.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:114a8f5b496881ed889798b438804d91a64d5fc478d0fb2c0d691842a65a0a23
+size 253613

--- a/whotracksme/data/assets/2021-01/eu/domains.csv
+++ b/whotracksme/data/assets/2021-01/eu/domains.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d4a6bc2ee75e32f0a4a7987d2a74c983126c86da0c71c535c61a481285bb459
+size 947652

--- a/whotracksme/data/assets/2021-01/eu/sites.csv
+++ b/whotracksme/data/assets/2021-01/eu/sites.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef72633352ddcda6dd0e8689c174ff2e0e3ae7d82789d40f5e6f9b07eb17463b
+size 3299717

--- a/whotracksme/data/assets/2021-01/eu/sites_trackers.csv
+++ b/whotracksme/data/assets/2021-01/eu/sites_trackers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c034bea0ea84d141767f5d6af2481299323d945e3e5214e4c1ef59b0b1e5e98
+size 54149404

--- a/whotracksme/data/assets/2021-01/eu/trackers.csv
+++ b/whotracksme/data/assets/2021-01/eu/trackers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2cfcc2e066dfaa858cd57357791225f234b71cc6d6466a99ddd5a8fde5d15e1
+size 429950

--- a/whotracksme/data/assets/2021-01/fr/companies.csv
+++ b/whotracksme/data/assets/2021-01/fr/companies.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a977b500a5bcf73aaed5798ffed04692482081c44c697afff8c34ff69a5a5ea6
+size 245277

--- a/whotracksme/data/assets/2021-01/fr/domains.csv
+++ b/whotracksme/data/assets/2021-01/fr/domains.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5ad8e31a5f21601acc6bd99697762167f82839250481d9ebf9a7160c937939a
+size 890857

--- a/whotracksme/data/assets/2021-01/fr/sites.csv
+++ b/whotracksme/data/assets/2021-01/fr/sites.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2907fa7387b9b950e8d51612e0d3985fbeef50797881eff3f5a7f21477f27c30
+size 2993018

--- a/whotracksme/data/assets/2021-01/fr/sites_trackers.csv
+++ b/whotracksme/data/assets/2021-01/fr/sites_trackers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1ef02e9fd664a467f9343680cc9a542bfc6f5de48dbc9f8aa14418e47d105e0
+size 34789822

--- a/whotracksme/data/assets/2021-01/fr/trackers.csv
+++ b/whotracksme/data/assets/2021-01/fr/trackers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26f7b99611a959b7c8ea837814abfbba16b3fbfff9ed5545dee64567f3d4e17e
+size 344771

--- a/whotracksme/data/assets/2021-01/global/companies.csv
+++ b/whotracksme/data/assets/2021-01/global/companies.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ace7ac7ff14843201b47f56c3005b8fe2479d0e6ab84b97c9f9764afbd2292e0
+size 260279

--- a/whotracksme/data/assets/2021-01/global/domains.csv
+++ b/whotracksme/data/assets/2021-01/global/domains.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c88be937741a05c2bd304252c9437aa85340b8217bc91afe2cab3b077d1aa0aa
+size 984140

--- a/whotracksme/data/assets/2021-01/global/sites.csv
+++ b/whotracksme/data/assets/2021-01/global/sites.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce31e7405ad955cc4e63b4bf79e6832579e9704e474b075afb5bb29c1fc372e6
+size 3376987

--- a/whotracksme/data/assets/2021-01/global/sites_trackers.csv
+++ b/whotracksme/data/assets/2021-01/global/sites_trackers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c90b01f1f506017278ee764ec8bce2596e246703a516de958286380cc858566
+size 63129353

--- a/whotracksme/data/assets/2021-01/global/trackers.csv
+++ b/whotracksme/data/assets/2021-01/global/trackers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75a8c6687c00face9c4301a9149d9de3dee40d711afa5496a3ffb178eeb4fb4e
+size 498702

--- a/whotracksme/data/assets/2021-01/us/companies.csv
+++ b/whotracksme/data/assets/2021-01/us/companies.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa6cb0d02b481780724e7652cf0fe7f7f789c3cf991610f314d959f1445f4e78
+size 251224

--- a/whotracksme/data/assets/2021-01/us/domains.csv
+++ b/whotracksme/data/assets/2021-01/us/domains.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26ac56bec05ac9cd2f6857928e761fc28b943e4bd6aa94a4492b002156e1b959
+size 944661

--- a/whotracksme/data/assets/2021-01/us/sites.csv
+++ b/whotracksme/data/assets/2021-01/us/sites.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b60d50216e5f2f76f0daff931236e3c93c8288b46c2d93529eb1c078d640608
+size 3141615

--- a/whotracksme/data/assets/2021-01/us/sites_trackers.csv
+++ b/whotracksme/data/assets/2021-01/us/sites_trackers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7aa8acd49321c77cea8e895098937c0cdf31aa9a84002126d5b6c1b82d575ee
+size 47036477

--- a/whotracksme/data/assets/2021-01/us/trackers.csv
+++ b/whotracksme/data/assets/2021-01/us/trackers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0061a480e8e2d1250d0374afb687f2619bb55ede970884d4e329364a335adf72
+size 407605


### PR DESCRIPTION
First half of #228, so the trackerdb cleanup does not block the release of the January data.