### PR TITLE
gha: install packages from requirements.txt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
           pip install -r requirements-dev.txt
           pip install -e '.[dev]'
           whotracksme --help

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ numpy==1.19.1
 pandas==1.1.2
 python-dateutil==2.8.1
 pytz==2020.1
-requests==2.24.0
+requests==2.25.1
 six==1.15.0
 urllib3==1.26.5


### PR DESCRIPTION
GitHub Actions installs Python packages only from requirements-dev.txt.
We should test requirements.txt too.

Fixes #245 