### PR TITLE
Revert "Bump websockets from 8.1 to 9.1 (#243)"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -74,5 +74,5 @@ urllib3==1.26.5
 uvloop==0.14.0
 watchdog==0.10.3
 webencodings==0.5.1
-websockets==9.1
+websockets==8.1
 yarl==1.5.1


### PR DESCRIPTION
This reverts commit ef8479f6c7ef1988abbb93206563e3444d2430ed.

Reverting for now to have a green main branch. Upgrading the libraries forces to upgrade the web framework sanic. That is a bigger change.